### PR TITLE
close channel

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -73,6 +73,7 @@ func ConsumeAll(ps []Producer, c Consumer, eh ErrorHandler) *Result {
 			result.ConsumeTime[i] = time.Now().Sub(from)
 		}
 		wg.Done()
+		close(ch)
 	}()
 
 	wg.Wait()


### PR DESCRIPTION
see
https://tour.golang.org/concurrency/4

worker呼び出し側の処理が関数抜け出せない、defer呼び出せないので関連ありそうなので、closeを入れてみる。
